### PR TITLE
Deprecate Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     description='Python SDK for the Ocean Data Platform',
     long_description="Connect to the Ocean Data Platform with Python through the Python SDK. Download queried ocean data easily and efficiently into data frames, for easy exploring and further processing in your data science project.",
     long_description_content_type="text/markdown",
+    python_requries=">=3.7",
     install_requires=[
         "cognite-sdk>=1.3",                      # Add project dependencies here
         "pandas>=0.20.0",
@@ -18,7 +19,7 @@ setuptools.setup(
     ],                                             
     url='https://github.com/C4IROcean/odp',  
     packages=setuptools.find_packages(),
-    classifiers=(                                 # Classifiers help people find your 
+    classifiers=(                                 # Classifiers help people find your
         "Programming Language :: Python :: 3",    # projects. See all possible classifiers 
         "License :: OSI Approved :: Apache Software License", # in https://pypi.org/classifiers/
         "Operating System :: OS Independent",   

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}, notebooks{36,37,38}
+envlist = py{36,37,38,39}, notebooks{36,37,38,39}
 #skip_missing_interpreters = true
 
 [testenv:notebooks]
@@ -13,9 +13,12 @@ commands =
 [testenv]
 deps = -r requirements.txt
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
+    notebooks37: python3.7
+    notebooks38: python3.8
+    notebooks39: python3.9
     notebooks: python3.8
 setenv =
     ODP_API_KEY={env:ODP_API_KEY}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}, notebooks{36,37,38,39}
+envlist = py{37,38,39}, notebooks{37,38,39}
 #skip_missing_interpreters = true
 
 [testenv:notebooks]


### PR DESCRIPTION
Deprecated Python 3.6 by setting `python>=3.7` in `setup.py` and removing tests in tox