### PR TITLE
ODP-879 OdpResourceClient pagination param

### DIFF
--- a/odp_sdk/__init__.py
+++ b/odp_sdk/__init__.py
@@ -1,0 +1,1 @@
+from .client import OdpClient

--- a/odp_sdk/client.py
+++ b/odp_sdk/client.py
@@ -4,6 +4,7 @@ from .auth import TokenProvider, get_default_token_provider
 from .http_client import OdpHttpClient
 from .raw_storage_client import OdpRawStorageClient
 from .resource_client import OdpResourceClient
+from .tabular_storage_client import OdpTabularStorageClient
 
 
 class OdpClient(BaseModel):
@@ -13,15 +14,17 @@ class OdpClient(BaseModel):
     token_provider: TokenProvider = Field(default_factory=get_default_token_provider)
 
     _http_client: OdpHttpClient = PrivateAttr()
-    _raw_storage_client: OdpRawStorageClient = PrivateAttr()
     _catalog_client: OdpResourceClient = PrivateAttr()
+    _raw_storage_client: OdpRawStorageClient = PrivateAttr()
+    _tabular_storage_client: OdpTabularStorageClient = PrivateAttr()
 
     def __init__(self, **data):
         super().__init__(**data)
 
         self._http_client = OdpHttpClient(base_url=self.base_url, token_provider=self.token_provider)
-        self._raw_storage_client = OdpRawStorageClient(http_client=self._http_client)
         self._catalog_client = OdpResourceClient(http_client=self._http_client, resource_endpoint="/catalog")
+        self._raw_storage_client = OdpRawStorageClient(http_client=self._http_client)
+        self._tabular_storage_client = OdpTabularStorageClient(http_client=self._http_client)
 
     @property
     def resource_store(self):
@@ -45,3 +48,7 @@ class OdpClient(BaseModel):
     @property
     def raw(self) -> OdpRawStorageClient:
         return self._raw_storage_client
+
+    @property
+    def tabular(self) -> OdpTabularStorageClient:
+        return self._tabular_storage_client

--- a/odp_sdk/resource_client.py
+++ b/odp_sdk/resource_client.py
@@ -104,7 +104,7 @@ class OdpResourceClient(BaseModel):
         if cursor:
             params["page"] = cursor
         if limit:
-            params["limit"] = limit
+            params["page_size"] = limit
 
         if oqs_filter:
             body = oqs_filter


### PR DESCRIPTION
Closes: ODP-879

- Changed `OdpResourceClient` pagination param from `limit` to `page_size`
- Added tabular to sdk client
- Added client to base `__init__.py`-file.