### PR TITLE
Catalog OQS query example

### DIFF
--- a/examples/catalog_oqs_query_example.py
+++ b/examples/catalog_oqs_query_example.py
@@ -5,12 +5,12 @@ client = OdpClient()
 # Filter collections
 
 oqs_filter = {
-  "oqs": { # When querying to the catalog, the oqs filter is passed inside an object named oqs.
-    "#EQUALS": [ #EQUALS is used here to compare to values
-      "$kind", #The first value is the kind from the metadata, prefaced with a dollarsign.
-      "catalog.hubocean.io/dataCollection" # And this is the value to compare with
-    ]
-  }
+    "oqs": {  # When querying to the catalog, the oqs filter is passed inside an object named oqs.
+        "#EQUALS": [  # EQUALS is used here to compare to values
+            "$kind",  # The first value is the kind from the metadata, prefaced with a dollarsign.
+            "catalog.hubocean.io/dataCollection",  # And this is the value to compare with
+        ]
+    }
 }
 
 

--- a/examples/catalog_oqs_query_example.py
+++ b/examples/catalog_oqs_query_example.py
@@ -1,0 +1,18 @@
+from odp_sdk.client import OdpClient
+
+client = OdpClient()
+
+# Filter collections
+
+oqs_filter = {
+  "oqs": { # When querying to the catalog, the oqs filter is passed inside an object named oqs.
+    "#EQUALS": [ #EQUALS is used here to compare to values
+      "$kind", #The first value is the kind from the metadata, prefaced with a dollarsign.
+      "catalog.hubocean.io/dataCollection" # And this is the value to compare with
+    ]
+  }
+}
+
+
+for item in client.catalog.list(oqs_filter):
+    print(item)


### PR DESCRIPTION
Adds simple example to query catalog with oqs.

```python
from odp_sdk.client import OdpClient

client = OdpClient()

# Filter collections

oqs_filter = {
  "oqs": { # When querying to the catalog, the oqs filter is passed inside an object named oqs.
    "#EQUALS": [ #EQUALS is used here to compare to values
      "$kind", #The first value is the kind from the metadata, prefaced with a dollarsign.
      "catalog.hubocean.io/dataCollection" # And this is the value to compare with
    ]
  }
}


for item in client.catalog.list(oqs_filter):
    print(item)
```