### PR TITLE
Raise exception with status code and error message from api.

### DIFF
--- a/odp_sdk/raw_storage_client.py
+++ b/odp_sdk/raw_storage_client.py
@@ -39,7 +39,7 @@ class OdpRawStorageClient(BaseModel):
 
         Returns:
             The metadata of the file corresponding to the reference
-
+requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
         Raises:
             OdpFileNotFoundError: If the file does not exist
         """
@@ -52,7 +52,7 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 404:
                 raise OdpFileNotFoundError(f"File not found: {file_metadata_dto.name}") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
         return FileMetadataDto(**response.json())
 
@@ -109,7 +109,7 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 401:
                 raise OdpValidationError("API argument error") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
         content = response.json()
         return [FileMetadataDto(**item) for item in content["results"]], content.get("next")
@@ -149,6 +149,7 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 404:
                 raise OdpFileNotFoundError(f"File not found: {filename}") from e
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
         return self.get_file_metadata(resource_dto, file_metadata_dto)
 
@@ -183,7 +184,7 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 401:
                 raise OdpValidationError("API argument error") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
         file_meta = FileMetadataDto(**response.json())
 
@@ -215,6 +216,7 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 404:
                 raise OdpFileNotFoundError(f"File not found: {file_metadata_dto.name}") from e
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
         if save_path:
             with open(save_path, "wb") as file:
@@ -242,3 +244,5 @@ class OdpRawStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 404:
                 raise OdpFileNotFoundError(f"File not found: {file_metadata_dto.name}") from e
+
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")

--- a/odp_sdk/raw_storage_client.py
+++ b/odp_sdk/raw_storage_client.py
@@ -31,17 +31,17 @@ class OdpRawStorageClient(BaseModel):
 
     def get_file_metadata(self, resource_dto: ResourceDto, file_metadata_dto: FileMetadataDto) -> FileMetadataDto:
         """
-        Get file metadata by reference.
+                Get file metadata by reference.
 
-        Args:
-            resource_dto: Dataset manifest
-            file_metadata_dto: File metadata to retrieve
+                Args:
+                    resource_dto: Dataset manifest
+                    file_metadata_dto: File metadata to retrieve
 
-        Returns:
-            The metadata of the file corresponding to the reference
-requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
-        Raises:
-            OdpFileNotFoundError: If the file does not exist
+                Returns:
+                    The metadata of the file corresponding to the reference
+        requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
+                Raises:
+                    OdpFileNotFoundError: If the file does not exist
         """
 
         url = self._construct_url(resource_dto, endpoint=f"/{file_metadata_dto.name}/metadata")

--- a/odp_sdk/resource_client.py
+++ b/odp_sdk/resource_client.py
@@ -60,8 +60,6 @@ class OdpResourceClient(BaseModel):
                 raise OdpResourceNotFoundError(f"Resource not found: {ref}") from e
             raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
 
-
-
         return ResourceDto(**res.json())
 
     def list(self, oqs_filter: Optional[dict] = None, cursor: Optional[str] = None) -> Iterable[ResourceDto]:

--- a/odp_sdk/resource_client.py
+++ b/odp_sdk/resource_client.py
@@ -58,7 +58,9 @@ class OdpResourceClient(BaseModel):
                 raise OdpValidationError("Invalid input") from e
             if res.status_code == 404:
                 raise OdpResourceNotFoundError(f"Resource not found: {ref}") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
+
+
 
         return ResourceDto(**res.json())
 
@@ -115,7 +117,7 @@ class OdpResourceClient(BaseModel):
         except requests.HTTPError as e:
             if res.status_code == 401:
                 raise OdpValidationError("API argument error") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
 
         content = res.json()
         return [ResourceDto(**item) for item in content["results"]], content.get("next")
@@ -142,7 +144,7 @@ class OdpResourceClient(BaseModel):
                 raise OdpValidationError("Invalid input", res.text) from e
             if res.status_code == 409:
                 raise OdpResourceExistsError("Resource already exists") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
 
         return ResourceDto(**res.json())
 
@@ -177,7 +179,7 @@ class OdpResourceClient(BaseModel):
                 raise OdpValidationError("Invalid input") from e
             if res.status_code == 404:
                 raise OdpResourceNotFoundError("Resource not found") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
 
         return ResourceDto(**res.json())
 
@@ -199,4 +201,4 @@ class OdpResourceClient(BaseModel):
         except requests.HTTPError as e:
             if res.status_code == 404:
                 raise OdpResourceNotFoundError(f"Resource not found: {ref}") from e
-            raise  # Unhandled error
+            raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")

--- a/odp_sdk/tabular_storage_client.py
+++ b/odp_sdk/tabular_storage_client.py
@@ -447,7 +447,7 @@ class OdpTabularStorageClient(BaseModel):
         except requests.HTTPError as e:
             if response.status_code == 404:
                 raise OdpResourceNotFoundError("Resource not found") from e
-            raise
+            raise requests.HTTPError(f"HTTP Error - {response.status_code}: {response.text}")
 
     def write_dataframe(self, resource_dto: ResourceDto, data: DataFrame, table_stage: Optional[TableStage] = None):
         """


### PR DESCRIPTION
closes [ODP-898](https://issues.hubocean.earth/issue/ODP-898) Relay API messages through the SDK

Add error message for all unhandled http errors.

Before:
```python
try:
    res.raise_for_status()
except requests.HTTPError as e:
    if res.status_code == 400:
        raise OdpValidationError("Invalid input") from e
    if res.status_code == 404:
        raise OdpResourceNotFoundError(f"Resource not found: {ref}") from e
    raise  # Unhandled err
```
After:

```python
  try:
      res.raise_for_status()
  except requests.HTTPError as e:
      if res.status_code == 400:
          raise OdpValidationError("Invalid input") from e
      if res.status_code == 404:
          raise OdpResourceNotFoundError(f"Resource not found: {ref}") from e
      raise requests.HTTPError(f"HTTP Error - {res.status_code}: {res.text}")
```