### PR TITLE
Remove typing for FileMetadataDto

### DIFF
--- a/odp_sdk/dto/file_dto.py
+++ b/odp_sdk/dto/file_dto.py
@@ -1,29 +1,27 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
 
 class FileMetadataDto(BaseModel):
-    class Config:
-        arbitrary_types_allowed = True
 
     """File Metadata Model."""
 
-    external_id: Optional[any] = None
-    name: Optional[str] = None
-    source: Optional[str] = None
-    mime_type: Optional[str] = None
-    metadata: Optional[Dict[str, str]] = None
-    directory: Optional[any] = None
-    asset_ids: Optional[List[any]] = None
-    data_set_id: Optional[any] = None
-    labels: Optional[List[any]] = None
-    geo_location: Optional[any] = None
-    source_created_time: Optional[any] = None
-    source_modified_time: Optional[any] = None
-    security_categories: Optional[List[any]] = None
-    id: Optional[any] = None
-    uploaded: Optional[any] = None
-    uploaded_time: Optional[any] = None
-    created_time: Optional[any] = None
-    last_updated_time: Optional[any] = None
+    external_id: Optional[Any] = None
+    name: Optional[Any] = None
+    source: Optional[Any] = None
+    mime_type: Optional[Any] = None
+    metadata: Optional[Dict[Any, Any]] = None
+    directory: Optional[Any] = None
+    asset_ids: Optional[List[Any]] = None
+    data_set_id: Optional[Any] = None
+    labels: Optional[List[Any]] = None
+    geo_location: Optional[Any] = None
+    source_created_time: Optional[Any] = None
+    source_modified_time: Optional[Any] = None
+    security_categories: Optional[List[Any]] = None
+    id: Optional[Any] = None
+    uploaded: Optional[Any] = None
+    uploaded_time: Optional[Any] = None
+    created_time: Optional[Any] = None
+    last_updated_time: Optional[Any] = None

--- a/odp_sdk/dto/file_dto.py
+++ b/odp_sdk/dto/file_dto.py
@@ -4,6 +4,9 @@ from pydantic import BaseModel
 
 
 class FileMetadataDto(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
     """File Metadata Model."""
 
     external_id: Optional[any] = None

--- a/odp_sdk/dto/file_dto.py
+++ b/odp_sdk/dto/file_dto.py
@@ -6,21 +6,21 @@ from pydantic import BaseModel
 class FileMetadataDto(BaseModel):
     """File Metadata Model."""
 
-    external_id: Optional[str] = None
+    external_id: Optional[any] = None
     name: Optional[str] = None
     source: Optional[str] = None
     mime_type: Optional[str] = None
     metadata: Optional[Dict[str, str]] = None
-    directory: Optional[str] = None
-    asset_ids: Optional[List[int]] = None
-    data_set_id: Optional[int] = None
-    labels: Optional[List[str]] = None
-    geo_location: Optional[str] = None
-    source_created_time: Optional[int] = None
-    source_modified_time: Optional[int] = None
-    security_categories: Optional[List[int]] = None
-    id: Optional[int] = None
-    uploaded: Optional[bool] = None
-    uploaded_time: Optional[int] = None
-    created_time: Optional[int | str] = None
-    last_updated_time: Optional[int] = None
+    directory: Optional[any] = None
+    asset_ids: Optional[List[any]] = None
+    data_set_id: Optional[any] = None
+    labels: Optional[List[any]] = None
+    geo_location: Optional[any] = None
+    source_created_time: Optional[any] = None
+    source_modified_time: Optional[any] = None
+    security_categories: Optional[List[any]] = None
+    id: Optional[any] = None
+    uploaded: Optional[any] = None
+    uploaded_time: Optional[any] = None
+    created_time: Optional[any] = None
+    last_updated_time: Optional[any] = None


### PR DESCRIPTION
closes [ODP-1034](https://issues.hubocean.earth/issue/ODP-1034) Incorrect DTO Definition in SDK

When passing geoJSON in geo_location for FileMetadataDto, users get this error:

```
ValidationError: 1 validation error for FileMetadataDto
geo_location
  Input should be a valid string [type=string_type, input_value={'type': 'Polygon', 'coor...0, 20.0], [55.0, 0.0]]]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
```
This is because geo_location field in the FileMetadataDto is defined like this:
```python
geo_location: Optional[str] = None
```

This PR changes all the fields to allow Any:

```python
class FileMetadataDto(BaseModel):

    """File Metadata Model."""

    external_id: Optional[Any] = None
    name: Optional[Any] = None
    source: Optional[Any] = None
    mime_type: Optional[Any] = None
    metadata: Optional[Dict[Any, Any]] = None
    directory: Optional[Any] = None
    asset_ids: Optional[List[Any]] = None
    data_set_id: Optional[Any] = None
    labels: Optional[List[Any]] = None
    geo_location: Optional[Any] = None
    source_created_time: Optional[Any] = None
    source_modified_time: Optional[Any] = None
    security_categories: Optional[List[Any]] = None
    id: Optional[Any] = None
    uploaded: Optional[Any] = None
    uploaded_time: Optional[Any] = None
    created_time: Optional[Any] = None
    last_updated_time: Optional[Any] = None
```