### PR TITLE
Fix error occurred when empty data list received

### DIFF
--- a/odp_sdk/tabular_storage_client.py
+++ b/odp_sdk/tabular_storage_client.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, Iterator, List, Optional
 from uuid import UUID
 
 import requests
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ValidationError, field_validator
 from requests import JSONDecodeError
 
 from odp_sdk.dto import ResourceDto
@@ -390,7 +390,7 @@ class OdpTabularStorageClient(BaseModel):
 
         try:
             result = PaginatedSelectResultSet(**response.json())
-        except JSONDecodeError:
+        except (JSONDecodeError, ValidationError):
             data = list(iter(NdJsonParser(response.text)))
             data = convert_geometry(data, result_geometry)
 


### PR DESCRIPTION
When an empty dataset is received since the response format is ndjson just a single json object depicting the end of the data is sent `{"@@end": true}`. Since this is a single object the code would try to parse it and create the `PaginatedSelectResultSet` and gets a validation error since the structure is not valid. Since in these cases we should still try and parse hthe data as an ndjson I moved this error to the `except` phrase where it is handled as ndjson.