### PR TITLE
ODP-1298 + ODP-1299: Rework tabular reads

### DIFF
--- a/odp_sdk/dto/resource_dto.py
+++ b/odp_sdk/dto/resource_dto.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
@@ -77,3 +77,29 @@ class ResourceDto(BaseModel):
 
     spec: Optional[dict] = None
     """Resource spec"""
+
+    def get_qualified_name(self) -> str:
+        """Get the resource qualified name
+
+        The qualified name is the kind and resource name joined by a slash: `{kind}/{metadata.name}`
+
+        Returns:
+            Qualified name
+        """
+        return f"{self.kind}/{self.metadata.name}"
+
+    def get_uuid(self) -> Optional[UUID]:
+        """Get the resource UUID
+
+        Returns:
+            Resource UUID if it is set, `None` otherwise
+        """
+        return self.metadata.uuid
+
+    def get_ref(self) -> Union[UUID, str]:
+        """Get a valid reference to the resource
+
+        Returns:
+            The resource UUID if it is set, the qualified name otherwise
+        """
+        return self.get_uuid() or self.get_qualified_name()

--- a/odp_sdk/dto/tabular_store.py
+++ b/odp_sdk/dto/tabular_store.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Dict, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel
@@ -36,13 +36,3 @@ class TableStage(BaseModel):
     def dict(self, **kwargs) -> "DictStrAny":  # noqa: F821
         exclude_unset = kwargs.pop("exclude_unset", True)
         return super().dict(exclude_unset=exclude_unset, **kwargs)
-
-
-class PaginatedSelectResultSet(BaseModel):
-    """Paginated select result set.
-
-    Contains the rows and the next page token of a query result.
-    """
-
-    data: List[Dict]
-    next: Optional[str] = None

--- a/odp_sdk/tabular_storage_client.py
+++ b/odp_sdk/tabular_storage_client.py
@@ -37,6 +37,9 @@ class OdpTabularStorageClient(BaseModel):
     paginate_by_default: bool = False
     """Whether to paginate by default"""
 
+    page_size_align_factor: int = 1000
+    """Page size alignment factor for pagination - ie. page size must be a multiple of this value"""
+
     @field_validator("tabular_storage_endpoint")
     def _endpoint_validator(cls, v: str):
         m = re.match(r"^/\w+(?<!/)", v)
@@ -266,6 +269,10 @@ class OdpTabularStorageClient(BaseModel):
 
         if limit:
             use_limit = min(use_limit, limit)
+
+        if use_limit % self.page_size_align_factor:
+            # Round up to the nearest multiple of the alignment factor
+            use_limit = (use_limit // self.page_size_align_factor + 1) * self.page_size_align_factor
 
         num_rows = 0
 

--- a/odp_sdk/tabular_storage_client.py
+++ b/odp_sdk/tabular_storage_client.py
@@ -264,6 +264,9 @@ class OdpTabularStorageClient(BaseModel):
         else:
             use_limit = self.chunked_encoding_page_size
 
+        if limit:
+            use_limit = min(use_limit, limit)
+
         num_rows = 0
 
         while True:

--- a/tests/test_examples/test_tabular_client_example.py
+++ b/tests/test_examples/test_tabular_client_example.py
@@ -39,10 +39,10 @@ def test_tabular_client(odp_client_test_uuid: Tuple[OdpClient, UUID]):
     odp_client_test_uuid[0].tabular.write(resource_dto=my_dataset, data=test_data)
 
     our_data = odp_client_test_uuid[0].tabular.select_as_list(my_dataset)
-    assert our_data != []
+    assert len(our_data) == 2
 
-    our_data = odp_client_test_uuid[0].tabular.select_as_stream(my_dataset)
-    assert our_data != []
+    our_data = list(odp_client_test_uuid[0].tabular.select_as_stream(my_dataset))
+    assert len(our_data) == 2
 
     update_filters = {"#EQUALS": ["$Data", "Test"]}
     new_data = [{"Data": "Test Updated"}]
@@ -53,12 +53,12 @@ def test_tabular_client(odp_client_test_uuid: Tuple[OdpClient, UUID]):
     )
 
     result = odp_client_test_uuid[0].tabular.select_as_list(my_dataset)
-    assert result != []
+    assert len(result) == 2
 
     delete_filters = {"#EQUALS": ["$Data", "Test1"]}
     odp_client_test_uuid[0].tabular.delete(resource_dto=my_dataset, filter_query=delete_filters)
     result = odp_client_test_uuid[0].tabular.select_as_list(my_dataset)
-    assert result != []
+    assert len(result) == 1
 
     odp_client_test_uuid[0].tabular.delete_schema(my_dataset)
 

--- a/tests/test_unit/test_tabular_storage_client.py
+++ b/tests/test_unit/test_tabular_storage_client.py
@@ -15,7 +15,7 @@ def test_create_schema_success(tabular_storage_client, tabular_resource_dto, tab
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
             body=table_spec.model_dump_json(),
             status=200,
             content_type="application/json",
@@ -31,7 +31,7 @@ def test_create_schema_fail_409(tabular_storage_client, tabular_resource_dto, ta
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
             status=409,
         )
 
@@ -43,7 +43,7 @@ def test_get_schema_success(tabular_storage_client, tabular_resource_dto, table_
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
             body=table_spec.model_dump_json(),
             status=200,
             content_type="application/json",
@@ -59,7 +59,7 @@ def test_get_schema_fail_404(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
             status=404,
         )
 
@@ -68,7 +68,7 @@ def test_get_schema_fail_404(tabular_storage_client, tabular_resource_dto):
 
 
 def test_delete_schema_success(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema?delete_data=False"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema") + "?delete_data=False"
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -86,7 +86,7 @@ def test_delete_schema_fail_404(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.DELETE,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/schema",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
             status=404,
         )
 
@@ -98,7 +98,7 @@ def test_create_stage_success(tabular_storage_client, tabular_resource_dto, tabl
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
             body=table_stage.model_dump_json(),
             status=200,
             content_type="application/json",
@@ -113,7 +113,7 @@ def test_create_stage_fail_409(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
             status=409,
         )
 
@@ -122,7 +122,7 @@ def test_create_stage_fail_409(tabular_storage_client, tabular_resource_dto):
 
 
 def test_commit_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage")
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -139,16 +139,14 @@ def test_get_stage_success(tabular_storage_client, tabular_resource_dto, table_s
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
-            f"/{table_stage.stage_id}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
             body=table_stage.model_dump_json(),
             status=200,
             content_type="application/json",
         )
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
-            f"/{table_stage.stage_id}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
             body=table_stage.model_dump_json(),
             status=200,
             content_type="application/json",
@@ -165,8 +163,7 @@ def test_get_stage_fail_400(tabular_storage_client, tabular_resource_dto, table_
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
-            f"/{table_stage.stage_id}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
             status=400,
         )
 
@@ -178,7 +175,7 @@ def test_list_stage_success(tabular_storage_client, tabular_resource_dto, table_
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
             body=f"[{table_stage.model_dump_json()}, {table_stage.model_dump_json()}]",
             status=200,
             content_type="application/json",
@@ -193,7 +190,7 @@ def test_list_stage_fail_400(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
             status=400,
         )
 
@@ -203,8 +200,8 @@ def test_list_stage_fail_400(tabular_storage_client, tabular_resource_dto):
 
 def test_delete_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
     url = (
-        f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
-        f"/{table_stage.stage_id}?force_delete=False"
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id))
+        + "?force_delete=False"
     )
 
     with responses.RequestsMock() as rsps:
@@ -223,8 +220,7 @@ def test_delete_stage_fail_400(tabular_storage_client, tabular_resource_dto, tab
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.DELETE,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/stage"
-            f"/{table_stage.stage_id}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
             status=400,
         )
 
@@ -236,7 +232,7 @@ def test_select_as_stream_success(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}',
             status=200,
             content_type="application/x-ndjson",
@@ -254,7 +250,7 @@ def test_select_as_list_success(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
@@ -271,7 +267,7 @@ def test_select_as_list_wkt_success(tabular_storage_client, tabular_resource_dto
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             body='{"test_key1": "POINT(0 0)"}\n{"test_key2": "POINT(0 1)"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
@@ -288,7 +284,7 @@ def test_select_as_list_wkb_success(tabular_storage_client, tabular_resource_dto
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             body='{"test_key1": "010100000000000000000000000000000000000000"}\n'
             '{"test_key2": "01010000000000000000000000000000000000f03f"}\n{"@@end": true}',
             status=200,
@@ -306,7 +302,7 @@ def test_select_as_stream_fail_404(tabular_storage_client, tabular_resource_dto)
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             status=404,
         )
 
@@ -319,7 +315,7 @@ def test_select_as_list_fail_404(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             status=404,
         )
 
@@ -331,7 +327,7 @@ def test_select_as_dataframe(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/list",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
             body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
@@ -345,7 +341,7 @@ def test_select_as_dataframe(tabular_storage_client, tabular_resource_dto):
 
 
 def test_write_small_success(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -365,7 +361,7 @@ def test_write_fail_404(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto),
             status=404,
         )
 
@@ -376,7 +372,7 @@ def test_write_fail_404(tabular_storage_client, tabular_resource_dto):
 
 
 def test_write_as_dataframe(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -393,7 +389,7 @@ def test_write_as_dataframe(tabular_storage_client, tabular_resource_dto):
 
 
 def test_delete_success(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/delete"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "delete")
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -411,7 +407,7 @@ def test_delete_fail_400(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.POST,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}/delete",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "delete"),
             status=404,
         )
 
@@ -420,7 +416,7 @@ def test_delete_fail_400(tabular_storage_client, tabular_resource_dto):
 
 
 def test_update_success(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -440,7 +436,7 @@ def test_update_fail_404(tabular_storage_client, tabular_resource_dto):
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.PATCH,
-            f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}",
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto),
             status=404,
         )
 
@@ -451,7 +447,7 @@ def test_update_fail_404(tabular_storage_client, tabular_resource_dto):
 
 
 def test_update_dataframe_success(tabular_storage_client, tabular_resource_dto):
-    url = f"{tabular_storage_client.tabular_storage_url}/{tabular_resource_dto.metadata.uuid}"
+    url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
     with responses.RequestsMock() as rsps:
         rsps.add(


### PR DESCRIPTION
Closes:
- ODP-1298
- ODP-1299

Summary:
- Refactored how tabular endpoints are constructed
- Fix tabular streaming
- Fix tabular pagination
- Fixed bug in `NdJsonParser` when consuming lines with data still left in the buffer