### PR TITLE
ODP-1279: Fix unexpected conversions

### DIFF
--- a/odp_sdk/tabular_storage_client.py
+++ b/odp_sdk/tabular_storage_client.py
@@ -377,8 +377,27 @@ class OdpTabularStorageClient(BaseModel):
             else:
                 is_meta = False
 
-            row = convert_geometry(row, result_geometry)
+            row = self._convert_geometry_with_schema(resource_dto, row, result_geometry)
             yield row, is_meta
+
+    def _convert_geometry_with_schema(self, resource_dto: ResourceDto, row: dict, result_geometry: str) -> dict:
+        try:
+            dataset_schema = self.get_schema(resource_dto)
+        except OdpResourceNotFoundError:
+            print(f"Schema not found for resource {resource_dto.metadata.name}: geometry conversion skipped")
+            return row
+
+        geometry_cols = [
+            column
+            for column, column_data in dataset_schema.table_schema.items()
+            if column_data.get("type") == "geometry"
+        ]
+        for col in geometry_cols:
+            try:
+                row[col] = convert_geometry(row[col], result_geometry)
+            except KeyError:
+                continue
+        return row
 
     def select_as_dataframe(self, resource_dto: ResourceDto, filter_query: Optional[dict] = None) -> DataFrame:
         """

--- a/tests/test_unit/test_tabular_storage_client.py
+++ b/tests/test_unit/test_tabular_storage_client.py
@@ -237,6 +237,11 @@ def test_select_as_stream_success(tabular_storage_client, tabular_resource_dto):
             status=200,
             content_type="application/x-ndjson",
         )
+        rsps.add(
+            responses.GET,
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+            status=404,
+        )
 
         response = tabular_storage_client.select_as_stream(tabular_resource_dto, filter_query=None)
         response_as_list = list(response)
@@ -255,6 +260,11 @@ def test_select_as_list_success(tabular_storage_client, tabular_resource_dto):
             status=200,
             content_type="application/x-ndjson",
         )
+        rsps.add(
+            responses.GET,
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+            status=404,
+        )
 
         response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
 
@@ -271,6 +281,12 @@ def test_select_as_list_wkt_success(tabular_storage_client, tabular_resource_dto
             body='{"test_key1": "POINT(0 0)"}\n{"test_key2": "POINT(0 1)"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
+        )
+        rsps.add(
+            responses.GET,
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+            json={"table_schema": {"test_key1": {"type": "geometry"}, "test_key2": {"type": "geometry"}}},
+            status=200,
         )
 
         response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
@@ -289,6 +305,12 @@ def test_select_as_list_wkb_success(tabular_storage_client, tabular_resource_dto
             '{"test_key2": "01010000000000000000000000000000000000f03f"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
+        )
+        rsps.add(
+            responses.GET,
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+            json={"table_schema": {"test_key1": {"type": "geometry"}, "test_key2": {"type": "geometry"}}},
+            status=200,
         )
 
         response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
@@ -328,15 +350,20 @@ def test_select_as_dataframe(tabular_storage_client, tabular_resource_dto):
         rsps.add(
             responses.POST,
             tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
+            body='{"test_key1": "Cameroonian Exclusive Economic Zone"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
+        )
+        rsps.add(
+            responses.GET,
+            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+            status=404,
         )
 
         response = tabular_storage_client.select_as_dataframe(tabular_resource_dto, filter_query=None)
 
         assert len(response) == 2
-        assert response["test_key1"][0] == "test_value"
+        assert response["test_key1"][0] == "Cameroonian Exclusive Economic Zone"
         assert response["test_key2"][1] == "test_value2"
 
 

--- a/tests/test_unit/test_tabular_storage_client.py
+++ b/tests/test_unit/test_tabular_storage_client.py
@@ -263,7 +263,8 @@ def test_select_as_list_success(tabular_storage_client, tabular_resource_dto):
         rsps.add(
             responses.GET,
             tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=404,
+            json={"table_schema": {"test_key1": {"type": "string"}, "test_key2": {"type": "string"}}},
+            status=200,
         )
 
         response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
@@ -278,14 +279,14 @@ def test_select_as_list_wkt_success(tabular_storage_client, tabular_resource_dto
         rsps.add(
             responses.POST,
             tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "POINT(0 0)"}\n{"test_key2": "POINT(0 1)"}\n{"@@end": true}',
+            body='{"test_key1": "POINT(0 0)"}\n{"test_key1": "POINT(0 1)"}\n{"@@end": true}',
             status=200,
             content_type="application/x-ndjson",
         )
         rsps.add(
             responses.GET,
             tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            json={"table_schema": {"test_key1": {"type": "geometry"}, "test_key2": {"type": "geometry"}}},
+            json={"table_schema": {"test_key1": {"type": "geometry"}}},
             status=200,
         )
 
@@ -293,7 +294,7 @@ def test_select_as_list_wkt_success(tabular_storage_client, tabular_resource_dto
 
         assert len(response) == 2
         assert response[0]["test_key1"] == {"coordinates": [0.0, 0.0], "type": "Point"}
-        assert response[1]["test_key2"] == {"coordinates": [0.0, 1.0], "type": "Point"}
+        assert response[1]["test_key1"] == {"coordinates": [0.0, 1.0], "type": "Point"}
 
 
 def test_select_as_list_wkb_success(tabular_storage_client, tabular_resource_dto):
@@ -454,7 +455,7 @@ def test_update_success(tabular_storage_client, tabular_resource_dto):
 
         data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
 
-        tabular_storage_client.update(tabular_resource_dto, filter_query=None, data=data)
+        tabular_storage_client.update(tabular_resource_dto, filter_query=dict(), data=data)
 
         assert rsps.assert_call_count(url, 1)
 
@@ -470,7 +471,7 @@ def test_update_fail_404(tabular_storage_client, tabular_resource_dto):
         data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
 
         with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.update(tabular_resource_dto, filter_query=None, data=data)
+            tabular_storage_client.update(tabular_resource_dto, filter_query=dict(), data=data)
 
 
 def test_update_dataframe_success(tabular_storage_client, tabular_resource_dto):


### PR DESCRIPTION
Closes ODP-1279:

certain strings were erroneously converted to Well-Known Binary (WKB) during the geometry conversion process. For instance, `Cameroonian Exclusive Economic Zone` was converted to `{"coordinates": [4.262550926741182e+257, 3.651985272256187e+228], "type": "Point"}`.

The root cause of this issue was that all columns were being converted to geometry, regardless of their original data type. This PR resolves the issue by ensuring that only rows of the geometry type are converted.