### PR TITLE
ODP-1239: Use validators library to check base_url

### DIFF
--- a/odp_sdk/http_client.py
+++ b/odp_sdk/http_client.py
@@ -1,9 +1,9 @@
 import json
-import re
 from contextlib import contextmanager
 from typing import Iterable, Literal, Optional
 
 import requests
+import validators
 from pydantic import BaseModel, field_validator
 
 from .auth import TokenProvider
@@ -18,12 +18,7 @@ class OdpHttpClient(BaseModel):
     @field_validator("base_url")
     @classmethod
     def _validate_url(cls, v: str) -> str:
-        m = re.match(
-            r"https?:\/\/(www\.|localhost)?[-a-zA-Z0-9@:%._\+~#=]"
-            r"{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*|:\d+)",
-            v,
-        )
-        if not m:
+        if not validators.url(v, simple_host=True):
             raise ValueError(f"Invalid base URL: {v}")
 
         return v.rstrip("/")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1083,10 +1083,21 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[[package]]
+name = "validators"
+version = "0.28.3"
+description = "Python Data Validation for Humans™"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "validators-0.28.3-py3-none-any.whl", hash = "sha256:53cafa854f13850156259d9cc479b864ee901f6a96e6b109e6fc33f98f37d99f"},
+    {file = "validators-0.28.3.tar.gz", hash = "sha256:c6c79840bcde9ba77b19f6218f7738188115e27830cbaff43264bc4ed24c429d"},
+]
+
 [extras]
 pandas = ["pandas"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7f2f1dc95409f1dc3990264c049d51ef09c5612363b509cd1c47191fa772517f"
+content-hash = "b3b89bdedbbcda87ced19fe9698ce27b67d333bf03639d4b98fca9fc8672b67e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ msal-extensions = "^1.1.0"
 pandas = { version = "^2.1.4", optional = true}
 shapely = "^2.0.4"
 geojson = "^3.1.0"
+validators = "^0.28.3"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Closes ODP-1239

This Pull Request addresses an issue where `http://localhost:8888` was previously considered an invalid URL, despite being a correct one.

Previously, our URL validation was implemented with a custom solution that did not correctly validate localhost URLs with port numbers. The new URL validation mechanism uses a well-established URL checker with the appropriate parameters configured to recognize localhost URLs with port numbers as valid URLs.