### PR TITLE
ODP-1300: Added more unit tests

### DIFF
--- a/src/sdk/tests/test_sdk/fixtures/__init__.py
+++ b/src/sdk/tests/test_sdk/fixtures/__init__.py
@@ -2,3 +2,5 @@ from .auth_fixtures import *  # noqa: F401, F403
 from .dto_fixtures import *  # noqa: F401, F403
 from .jwt_fixtures import *  # noqa: F401, F403
 from .odp_http_client_fixtures import *  # noqa: F401, F403
+from .request_fixtures import *  # noqa: F401, F403
+from .time_fixtures import *  # noqa: F401, F403

--- a/src/sdk/tests/test_sdk/fixtures/dto_fixtures.py
+++ b/src/sdk/tests/test_sdk/fixtures/dto_fixtures.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import pytest
 from odp.client.dto.table_spec import TableSpec
 from odp.client.dto.tabular_store import TableStage
-from odp.dto import Metadata, ResourceDto
+from odp.dto import DatasetDto, DatasetSpec, Metadata
 
 __all__ = [
     "raw_resource_dto",
@@ -13,32 +13,41 @@ __all__ = [
     "table_stage",
 ]
 
+from odp.dto.common.contact_info import ContactInfo
+
 
 @pytest.fixture()
-def raw_resource_dto():
+def raw_resource_dto() -> DatasetDto:
     name = "test_dataset"
-    kind = "catalog.hubocean.io/dataset"
-    version = "v1alpha3"
     uuid = uuid4()
-    return ResourceDto(
-        kind=kind,
-        version=version,
+    return DatasetDto(
         metadata=Metadata(name=name, uuid=uuid),
-        spec=dict(
+        spec=DatasetSpec(
             storage_class="registry.hubocean.io/storageClass/raw",
-            maintainer={"organization": "HUB Ocean"},
+            maintainer=ContactInfo(
+                organization="HUB Ocean", contact="Name McNameson <name.mcnameson@emailprovider.com>"
+            ),
             documentation=["https://oceandata.earth"],
-            tags=["test", "hubocean"],
+            tags={"test", "hubocean"},
         ),
     )
 
 
 @pytest.fixture()
-def tabular_resource_dto() -> ResourceDto:
+def tabular_resource_dto() -> DatasetDto:
     name = "test_dataset"
     uuid = uuid4()
-    return ResourceDto[dict](
-        kind="test.hubocean.io/testType", version="v1alpha1", metadata=Metadata(name=name, uuid=uuid), spec={}
+
+    return DatasetDto(
+        metadata=Metadata(name=name, uuid=uuid),
+        spec=DatasetSpec(
+            storage_class="registry.hubocean.io/storageClass/tabular",
+            maintainer=ContactInfo(
+                organization="HUB Ocean", contact="Name McNameson <name.mcnameson@emailprovider.com>"
+            ),
+            documentation=["https://oceandata.earth"],
+            tags={"test", "hubocean"},
+        ),
     )
 
 

--- a/src/sdk/tests/test_sdk/fixtures/jwt_fixtures.py
+++ b/src/sdk/tests/test_sdk/fixtures/jwt_fixtures.py
@@ -133,11 +133,11 @@ def encode_token(payload: dict, private_key: rsa.RSAPrivateKey) -> str:
 
 @pytest.fixture()
 def jwt_token_provider(
+    request_mock: responses.RequestsMock,
     rsa_public_key: rsa.RSAPublicKey,
     rsa_private_key: rsa.RSAPrivateKey,
 ) -> JwtTokenProvider:
-    with responses.RequestsMock(assert_all_requests_are_fired=False) as mock:
-        auth_response(mock, rsa_private_key)
-        jwt_response(mock, rsa_public_key)
+    auth_response(request_mock, rsa_private_key)
+    jwt_response(request_mock, rsa_public_key)
 
-        yield MockTokenProvider()
+    yield MockTokenProvider()

--- a/src/sdk/tests/test_sdk/fixtures/odp_http_client_fixtures.py
+++ b/src/sdk/tests/test_sdk/fixtures/odp_http_client_fixtures.py
@@ -1,12 +1,9 @@
-from uuid import UUID
-
 import pytest
 from odp.client.auth import TokenProvider
 from odp.client.http_client import OdpHttpClient
 
 __all__ = [
     "mock_odp_endpoint",
-    "mock_token_provider",
     "http_client",
 ]
 
@@ -16,21 +13,6 @@ def mock_odp_endpoint() -> str:
     return "http://odp.local"
 
 
-@pytest.fixture(scope="session")
-def mock_token_provider() -> TokenProvider:
-    class MockTokenProvider(TokenProvider):
-        def __init__(self):
-            super().__init__()
-
-        def get_token(self) -> str:
-            return "Bearer abc"
-
-        def get_user_id(self) -> str:
-            return str(UUID(int=1234567890))
-
-    return MockTokenProvider()
-
-
-@pytest.fixture(scope="session")
-def http_client(mock_odp_endpoint: str, mock_token_provider: TokenProvider) -> OdpHttpClient:
-    return OdpHttpClient(base_url=mock_odp_endpoint, token_provider=mock_token_provider)
+@pytest.fixture
+def http_client(mock_odp_endpoint: str, jwt_token_provider: TokenProvider) -> OdpHttpClient:
+    return OdpHttpClient(base_url=mock_odp_endpoint, token_provider=jwt_token_provider)

--- a/src/sdk/tests/test_sdk/fixtures/request_fixtures.py
+++ b/src/sdk/tests/test_sdk/fixtures/request_fixtures.py
@@ -1,0 +1,8 @@
+import pytest
+import responses
+
+
+@pytest.fixture
+def request_mock() -> responses.RequestsMock:
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        yield rsps

--- a/src/sdk/tests/test_sdk/fixtures/time_fixtures.py
+++ b/src/sdk/tests/test_sdk/fixtures/time_fixtures.py
@@ -1,0 +1,43 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_sleep(request: pytest.FixtureRequest):
+    if request.node.get_closest_marker("mock_sleep"):
+        with patch.object(time, "sleep", lambda x: None):
+            yield
+    else:
+        yield
+
+
+class MockTime:
+    def __init__(self, use_time: float):
+        self.use_time = use_time
+
+    def get_time(self) -> float:
+        return self.use_time
+
+    def __enter__(self):
+        self.patcher = patch.object(time, "time", lambda: self.use_time)
+        self.patcher.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.patcher.stop()
+
+    def advance(self, seconds: float):
+        self.use_time += seconds
+
+
+@pytest.fixture(autouse=True)
+def mock_time(request: pytest.FixtureRequest):
+    if marker := request.node.get_closest_marker("mock_time"):
+        use_time = marker.kwargs.get("use_time", 1560926388)
+        mock_timer = MockTime(use_time)
+
+        with mock_timer:
+            yield mock_timer
+    else:
+        yield None

--- a/src/sdk/tests/test_sdk/test_auth/test_azure_token_provider.py
+++ b/src/sdk/tests/test_sdk/test_auth/test_azure_token_provider.py
@@ -1,3 +1,6 @@
+from typing import Callable
+
+import pytest
 import responses
 from odp.client.auth import AzureTokenProvider
 
@@ -10,9 +13,96 @@ def test_get_token(azure_token_provider: AzureTokenProvider, mock_token_response
             body=mock_token_response_body,
         )
         access_token = azure_token_provider.get_token()
+
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+        assert access_token
+
+
+def test_get_token_reuse(azure_token_provider: AzureTokenProvider, mock_token_response_body: str):
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.POST,
+            azure_token_provider.token_uri,
+            body=mock_token_response_body,
+        )
+        access_token = azure_token_provider.get_token()
+
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
         assert access_token
 
         new_access_token = azure_token_provider.get_token()
-        assert access_token == new_access_token
 
         assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+        assert access_token == new_access_token
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_get_token_renew(
+    azure_token_provider: AzureTokenProvider, mock_token_response_callback: Callable[[], str], mock_time
+):
+    with responses.RequestsMock() as rsps:
+        rsps.add_callback(
+            responses.POST,
+            azure_token_provider.token_uri,
+            callback=lambda _: (200, {}, mock_token_response_callback()),
+            content_type="application/json",
+        )
+
+        access_token = azure_token_provider.get_token()
+        assert access_token
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+
+        mock_time.advance(3600)
+
+        new_access_token = azure_token_provider.get_token()
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 2)
+        assert new_access_token
+        assert new_access_token != access_token
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_get_token_renew_before_leeway(
+    azure_token_provider: AzureTokenProvider, mock_token_response_callback: Callable[[], str], mock_time
+):
+    with responses.RequestsMock() as rsps:
+        rsps.add_callback(
+            responses.POST,
+            azure_token_provider.token_uri,
+            callback=lambda _: (200, {}, mock_token_response_callback()),
+            content_type="application/json",
+        )
+
+        access_token = azure_token_provider.get_token()
+        assert access_token
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+
+        mock_time.advance(3600 - (azure_token_provider.token_exp_lee_way + 1))
+
+        new_access_token = azure_token_provider.get_token()
+
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+        assert new_access_token == access_token
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_get_token_renew_after_leeway(
+    azure_token_provider: AzureTokenProvider, mock_token_response_callback: Callable[[], str], mock_time
+):
+    with responses.RequestsMock() as rsps:
+        rsps.add_callback(
+            responses.POST,
+            azure_token_provider.token_uri,
+            callback=lambda _: (200, {}, mock_token_response_callback()),
+            content_type="application/json",
+        )
+
+        access_token = azure_token_provider.get_token()
+        assert access_token
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 1)
+
+        mock_time.advance(3600 - (azure_token_provider.token_exp_lee_way - 1))
+
+        new_access_token = azure_token_provider.get_token()
+        assert rsps.assert_call_count(azure_token_provider.token_uri, 2)
+        assert new_access_token
+        assert new_access_token != access_token

--- a/src/sdk/tests/test_sdk/test_auth/test_jwks_token_provider.py
+++ b/src/sdk/tests/test_sdk/test_auth/test_jwks_token_provider.py
@@ -1,4 +1,7 @@
+import pytest
+import responses
 from odp.client.auth import JwtTokenProvider
+from test_sdk.fixtures.jwt_fixtures import MOCK_TOKEN_ENDPOINT
 
 
 def test_authenticate(jwt_token_provider: JwtTokenProvider):
@@ -38,3 +41,57 @@ def test_get_token_validate(jwt_token_provider: JwtTokenProvider):
 
     assert new_access_token.startswith(expected_prefix)
     assert access_token == new_access_token
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_renew_token(jwt_token_provider: JwtTokenProvider, request_mock: responses.RequestsMock, mock_time):
+    responses.assert_call_count(MOCK_TOKEN_ENDPOINT, 0)
+
+    access_token = jwt_token_provider.get_token()
+    assert access_token
+    request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+    new_access_token = jwt_token_provider.get_token()
+    assert access_token == new_access_token
+    request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+    mock_time.advance(3600)
+
+    new_access_token = jwt_token_provider.get_token()
+    assert access_token != new_access_token
+    request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 2)
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_renew_token_before_leeway(
+    jwt_token_provider: JwtTokenProvider, request_mock: responses.RequestsMock, mock_time
+):
+    responses.assert_call_count(MOCK_TOKEN_ENDPOINT, 0)
+
+    access_token = jwt_token_provider.get_token()
+    assert access_token
+    request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+    mock_time.advance(3600 - (jwt_token_provider.token_exp_lee_way + 1))
+
+    new_access_token = jwt_token_provider.get_token()
+    assert access_token == new_access_token
+    request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_renew_token_after_leeway(
+    jwt_token_provider: JwtTokenProvider, request_mock: responses.RequestsMock, mock_time
+):
+    responses.assert_call_count(MOCK_TOKEN_ENDPOINT, 0)
+
+    access_token = jwt_token_provider.get_token()
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+    assert access_token
+
+    mock_time.advance(3600 - (jwt_token_provider.token_exp_lee_way - 1))
+
+    new_access_token = jwt_token_provider.get_token()
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 2)
+    assert new_access_token
+    assert access_token != new_access_token

--- a/src/sdk/tests/test_sdk/test_http_client.py
+++ b/src/sdk/tests/test_sdk/test_http_client.py
@@ -2,33 +2,32 @@ import pytest
 import responses
 from odp.client.auth import TokenProvider
 from odp.client.http_client import OdpHttpClient
+from test_sdk.fixtures.jwt_fixtures import MOCK_TOKEN_ENDPOINT
 
 
-def test_request_relative(http_client):
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, f"{http_client.base_url}/foobar", status=200)
+def test_request_relative(http_client: OdpHttpClient, request_mock: responses.RequestsMock):
+    request_mock.add(responses.GET, f"{http_client.base_url}/foobar", status=200)
 
-        res = http_client.get("/foobar")
-        res.raise_for_status()
+    res = http_client.get("/foobar")
+    res.raise_for_status()
 
-        assert res.status_code == 200
+    assert res.status_code == 200
 
 
-def test_request_absolute(http_client):
+def test_request_absolute(http_client: OdpHttpClient, request_mock: responses.RequestsMock):
     test_url = "http://someurl.local"
 
     assert test_url != http_client.base_url
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, test_url, status=200)
+    request_mock.add(responses.GET, test_url, status=200)
 
-        res = http_client.get(test_url)
-        res.raise_for_status()
+    res = http_client.get(test_url)
+    res.raise_for_status()
 
-        assert res.status_code == 200
+    assert res.status_code == 200
 
 
-def test_request_has_auth_token(http_client):
+def test_request_has_auth_token(http_client: OdpHttpClient, request_mock: responses.RequestsMock):
     def _on_request(request):
         assert "Authorization" in request.headers
 
@@ -38,17 +37,51 @@ def test_request_has_auth_token(http_client):
 
         return (200, {}, None)
 
-    with responses.RequestsMock() as rsps:
-        rsps.add_callback(
-            responses.GET,
-            f"{http_client.base_url}/foobar",
-            callback=_on_request,
-        )
+    request_mock.add_callback(
+        responses.GET,
+        f"{http_client.base_url}/foobar",
+        callback=_on_request,
+    )
 
-        http_client.get("/foobar")
+    http_client.get("/foobar")
 
 
-def test_custom_user_agent(http_client):
+def test_request_reuse_auth_token(http_client: OdpHttpClient, request_mock: responses.RequestsMock):
+    request_mock.add(responses.GET, f"{http_client.base_url}/foobar", status=200)
+
+    res = http_client.get("/foobar")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+    res = http_client.get("/foobar")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+
+@pytest.mark.mock_time(use_time=123)
+def test_request_renew_auth_token(http_client: OdpHttpClient, request_mock: responses.RequestsMock, mock_time):
+    request_mock.add(responses.GET, f"{http_client.base_url}/foobar", status=200)
+
+    res = http_client.get("/foobar")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 1)
+
+    mock_time.advance(3600)
+
+    res = http_client.get("/foobar")
+    res.raise_for_status()
+
+    assert res.status_code == 200
+    assert request_mock.assert_call_count(MOCK_TOKEN_ENDPOINT, 2)
+
+
+def test_custom_user_agent(http_client: OdpHttpClient, request_mock: responses.RequestsMock):
     custom_user_agent = "my-custom-user-agent"
 
     http_client.custom_user_agent = custom_user_agent
@@ -57,14 +90,14 @@ def test_custom_user_agent(http_client):
 
     assert test_url != http_client.base_url
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, test_url, status=200)
+    request_mock.add(responses.GET, test_url, status=200)
 
-        res = http_client.get(test_url)
-        res.raise_for_status()
+    res = http_client.get(test_url)
+    res.raise_for_status()
 
-        assert res.status_code == 200
-        assert rsps.calls[0].request.headers["User-Agent"] == custom_user_agent
+    assert res.status_code == 200
+
+    assert request_mock.calls[1].request.headers["User-Agent"] == custom_user_agent
 
 
 @pytest.mark.parametrize(
@@ -77,9 +110,9 @@ def test_custom_user_agent(http_client):
         ("not a valid url", False),
     ],
 )
-def test_http_client_url(mock_token_provider: TokenProvider, url: str, expected: bool):
+def test_http_client_url(jwt_token_provider: TokenProvider, url: str, expected: bool):
     try:
-        http_client = OdpHttpClient(base_url=url, token_provider=mock_token_provider)
+        http_client = OdpHttpClient(base_url=url, token_provider=jwt_token_provider)
         assert http_client.base_url == url and expected
     except ValueError:
         assert not expected

--- a/src/sdk/tests/test_sdk/test_raw_storage_client.py
+++ b/src/sdk/tests/test_sdk/test_raw_storage_client.py
@@ -1,20 +1,25 @@
 import json
 import uuid
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 import responses
 from odp.client.dto.file_dto import FileMetadataDto
 from odp.client.exc import OdpFileNotFoundError
+from odp.client.http_client import OdpHttpClient
 from odp.client.raw_storage_client import OdpRawStorageClient
+from odp.dto import DatasetDto
 
 
 @pytest.fixture()
-def raw_storage_client(http_client) -> OdpRawStorageClient:
+def raw_storage_client(http_client: OdpHttpClient) -> OdpRawStorageClient:
     return OdpRawStorageClient(http_client=http_client, raw_storage_endpoint="/data")
 
 
-def test_get_file_metadata_success(raw_storage_client, raw_resource_dto):
+def test_get_file_metadata_success(
+    raw_storage_client: OdpRawStorageClient, raw_resource_dto: DatasetDto, request_mock: responses.RequestsMock
+):
     rand_uuid = uuid.uuid4()
     time_now = datetime.now()
     file_meta = FileMetadataDto(
@@ -30,129 +35,144 @@ def test_get_file_metadata_success(raw_storage_client, raw_resource_dto):
         deleted_time=time_now,
     )
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_meta.name}/metadata",
-            body=file_meta.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.GET,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_meta.name}/metadata",
+        body=file_meta.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
 
-        result = raw_storage_client.get_file_metadata(raw_resource_dto, file_meta)
+    result = raw_storage_client.get_file_metadata(raw_resource_dto, file_meta)
 
-        assert result.name == "file.zip"
-        assert result.mime_type == "application/zip"
-        assert result.dataset == rand_uuid
-        assert result.metadata == {"name": "sdk-raw-example"}
-        assert result.geo_location == "Somewhere"
-        assert result.size_bytes == 123456789
-        assert result.checksum == "asdf"
-        assert result.created_time == time_now
-        assert result.modified_time == time_now
-        assert result.deleted_time == time_now
+    assert result.name == "file.zip"
+    assert result.mime_type == "application/zip"
+    assert result.dataset == rand_uuid
+    assert result.metadata == {"name": "sdk-raw-example"}
+    assert result.geo_location == "Somewhere"
+    assert result.size_bytes == 123456789
+    assert result.checksum == "asdf"
+    assert result.created_time == time_now
+    assert result.modified_time == time_now
+    assert result.deleted_time == time_now
 
 
-def test_get_file_metadata_not_found(raw_storage_client, raw_resource_dto):
+def test_get_file_metadata_not_found(
+    raw_storage_client: OdpRawStorageClient,
+    raw_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     file_meta = FileMetadataDto(name="file.zip", mime_type="application/zip")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_meta.name}/metadata",
-            status=404,
-        )
+    request_mock.add(
+        responses.GET,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_meta.name}/metadata",
+        status=404,
+    )
 
-        with pytest.raises(OdpFileNotFoundError):
-            raw_storage_client.get_file_metadata(raw_resource_dto, file_meta)
+    with pytest.raises(OdpFileNotFoundError):
+        raw_storage_client.get_file_metadata(raw_resource_dto, file_meta)
 
 
-def test_list_files_success(raw_storage_client, raw_resource_dto):
+def test_list_files_success(
+    raw_storage_client: OdpRawStorageClient,
+    raw_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     file_metadata = FileMetadataDto(name="file.zip", mime_type="application/zip")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/list",
-            json={
-                "results": [json.loads(file_metadata.model_dump_json())],
-                "next": None,
-                "num_results": 1,
-            },
-            status=200,
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.POST,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/list",
+        json={
+            "results": [json.loads(file_metadata.model_dump_json())],
+            "next": None,
+            "num_results": 1,
+        },
+        status=200,
+        content_type="application/json",
+    )
 
-        metadata_filter = {"name": file_metadata.name}
+    metadata_filter = {"name": file_metadata.name}
 
-        result = raw_storage_client.list(raw_resource_dto, metadata_filter=metadata_filter)
+    result = raw_storage_client.list(raw_resource_dto, metadata_filter=metadata_filter)
 
-        first_item = next(iter(result))
+    first_item = next(iter(result))
 
-        assert first_item.name == file_metadata.name
-        assert first_item.mime_type == file_metadata.mime_type
+    assert first_item.name == file_metadata.name
+    assert first_item.mime_type == file_metadata.mime_type
 
 
-def test_create_file_success(raw_storage_client, raw_resource_dto):
+def test_create_file_success(
+    raw_storage_client: OdpRawStorageClient,
+    raw_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     file_metadata = FileMetadataDto(
         name="new_file.txt",
         mime_type="text/plain",
     )
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}",
-            status=200,
-            json=json.loads(file_metadata.model_dump_json()),
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.POST,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}",
+        status=200,
+        json=json.loads(file_metadata.model_dump_json()),
+        content_type="application/json",
+    )
 
-        rsps.add(
-            responses.GET,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}/metadata",
-            json=json.loads(file_metadata.model_dump_json()),
-            status=200,
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.GET,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}/metadata",
+        json=json.loads(file_metadata.model_dump_json()),
+        status=200,
+        content_type="application/json",
+    )
 
-        result = raw_storage_client.create_file(raw_resource_dto, file_metadata_dto=file_metadata, contents=None)
+    result = raw_storage_client.create_file(raw_resource_dto, file_metadata_dto=file_metadata, contents=None)
 
-        assert result.name == file_metadata.name
-        assert result.mime_type == "text/plain"
+    assert result.name == file_metadata.name
+    assert result.mime_type == "text/plain"
 
 
-def test_download_file_save(raw_storage_client, raw_resource_dto, tmp_path):
+def test_download_file_save(
+    raw_storage_client: OdpRawStorageClient,
+    raw_resource_dto: DatasetDto,
+    tmp_path: Path,
+    request_mock: responses.RequestsMock,
+):
     file_data = b"Sample file content"
     save_path = tmp_path / "downloaded_file.txt"
 
     file_metadata = FileMetadataDto(name="test_file.txt", mime_type="text/plain")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}",
-            body=file_data,
-            status=200,
-        )
+    request_mock.add(
+        responses.GET,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}",
+        body=file_data,
+        status=200,
+    )
 
-        raw_storage_client.download_file(raw_resource_dto, file_metadata, save_path=str(save_path))
+    raw_storage_client.download_file(raw_resource_dto, file_metadata, save_path=str(save_path))
 
-        with open(save_path, "rb") as file:
-            saved_data = file.read()
+    with open(save_path, "rb") as file:
+        saved_data = file.read()
 
     assert saved_data == file_data
 
 
-def test_delete_file_not_found(raw_storage_client, raw_resource_dto):
+def test_delete_file_not_found(
+    raw_storage_client: OdpRawStorageClient,
+    raw_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     file_metadata = FileMetadataDto(name="test_file.txt", mime_type="text/plain")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.DELETE,
-            f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}",
-            status=404,  # Assuming status code 404 indicates file not found
-        )
+    request_mock.add(
+        responses.DELETE,
+        f"{raw_storage_client.raw_storage_url}/{raw_resource_dto.metadata.uuid}/{file_metadata.name}",
+        status=404,  # Assuming status code 404 indicates file not found
+    )
 
-        with pytest.raises(OdpFileNotFoundError):
-            raw_storage_client.delete_file(raw_resource_dto, file_metadata)
+    with pytest.raises(OdpFileNotFoundError):
+        raw_storage_client.delete_file(raw_resource_dto, file_metadata)

--- a/src/sdk/tests/test_sdk/test_resource_client.py
+++ b/src/sdk/tests/test_sdk/test_resource_client.py
@@ -13,77 +13,84 @@ def resource_client(http_client) -> OdpResourceClient:
     return OdpResourceClient(http_client=http_client, resource_endpoint="/foobar")
 
 
-def test_get_resource_by_uuid(resource_client):
+def test_get_resource_by_uuid(
+    resource_client: OdpResourceClient,
+    request_mock: responses.RequestsMock,
+):
     kind = "test.hubocean.io/tesType"
     version = "v1alpha1"
     name = "test"
     uuid = uuid4()
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"{resource_client.resource_url}/{uuid}",
-            body=ResourceDto(
-                kind=kind,
-                version=version,
-                metadata=Metadata(name=name, uuid=uuid),
-                status=ResourceStatus(
-                    num_updates=0,
-                    created_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
-                    created_by=uuid4(),
-                    updated_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
-                    updated_by=uuid4(),
-                ),
-                spec={},
-            ).model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.GET,
+        f"{resource_client.resource_url}/{uuid}",
+        body=ResourceDto(
+            kind=kind,
+            version=version,
+            metadata=Metadata(name=name, uuid=uuid),
+            status=ResourceStatus(
+                num_updates=0,
+                created_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
+                created_by=uuid4(),
+                updated_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
+                updated_by=uuid4(),
+            ),
+            spec={},
+        ).model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
 
-        manifest = resource_client.get(uuid)
+    manifest = resource_client.get(uuid)
 
-        assert manifest.kind == kind
-        assert manifest.version == version
-        assert manifest.metadata.name == name
+    assert manifest.kind == kind
+    assert manifest.version == version
+    assert manifest.metadata.name == name
 
 
-def test_get_resource_by_qname(resource_client):
+def test_get_resource_by_qname(
+    resource_client: OdpResourceClient,
+    request_mock: responses.RequestsMock,
+):
     kind = "test.hubocean.io/tesType"
     version = "v1alpha1"
     name = "test"
     uuid = uuid4()
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            f"{resource_client.resource_url}/{kind}/{name}",
-            body=ResourceDto(
-                kind=kind,
-                version=version,
-                metadata=Metadata(name=name, uuid=uuid),
-                status=ResourceStatus(
-                    num_updates=0,
-                    created_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
-                    created_by=uuid4(),
-                    updated_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
-                    updated_by=uuid4(),
-                ),
-                spec={},
-            ).model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
+    request_mock.add(
+        responses.GET,
+        f"{resource_client.resource_url}/{kind}/{name}",
+        body=ResourceDto(
+            kind=kind,
+            version=version,
+            metadata=Metadata(name=name, uuid=uuid),
+            status=ResourceStatus(
+                num_updates=0,
+                created_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
+                created_by=uuid4(),
+                updated_time=datetime.fromisoformat("2021-01-01T00:00:00+00:00"),
+                updated_by=uuid4(),
+            ),
+            spec={},
+        ).model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
 
-        manifest = resource_client.get(f"{kind}/{name}")
+    manifest = resource_client.get(f"{kind}/{name}")
 
-        assert manifest.kind == kind
-        assert manifest.version == version
-        assert manifest.metadata.name == name
-        assert manifest.metadata.uuid == uuid
-        assert manifest.metadata.uuid == uuid
+    assert manifest.kind == kind
+    assert manifest.version == version
+    assert manifest.metadata.name == name
+    assert manifest.metadata.uuid == uuid
+    assert manifest.metadata.uuid == uuid
 
 
-def test_create_resource(resource_client):
+def test_create_resource(
+    resource_client: OdpResourceClient,
+    request_mock: responses.RequestsMock,
+):
     def _on_create_request(request):
         manifest = json.loads(request.body)
 
@@ -112,19 +119,18 @@ def test_create_resource(resource_client):
         spec=dict(),
     )
 
-    with responses.RequestsMock() as rsps:
-        rsps.add_callback(
-            responses.POST,
-            f"{resource_client.resource_url}",
-            callback=_on_create_request,
-            content_type="application/json",
-        )
+    request_mock.add_callback(
+        responses.POST,
+        f"{resource_client.resource_url}",
+        callback=_on_create_request,
+        content_type="application/json",
+    )
 
-        populated_manifest = resource_client.create(resource_manifest)
+    populated_manifest = resource_client.create(resource_manifest)
 
-        assert isinstance(populated_manifest, ResourceDto)
-        assert populated_manifest.metadata.uuid is not None
-        assert populated_manifest.status is not None
-        assert populated_manifest.status.num_updates == 0
-        assert populated_manifest.kind == resource_manifest.kind
-        assert populated_manifest.metadata.name == resource_manifest.metadata.name
+    assert isinstance(populated_manifest, ResourceDto)
+    assert populated_manifest.metadata.uuid is not None
+    assert populated_manifest.status is not None
+    assert populated_manifest.status.num_updates == 0
+    assert populated_manifest.kind == resource_manifest.kind
+    assert populated_manifest.metadata.name == resource_manifest.metadata.name

--- a/src/sdk/tests/test_sdk/test_tabular_storage_client.py
+++ b/src/sdk/tests/test_sdk/test_tabular_storage_client.py
@@ -1,490 +1,596 @@
 import pytest
 import responses
+from odp.client.dto.table_spec import TableSpec
+from odp.client.dto.tabular_store import TableStage
 from odp.client.exc import OdpResourceExistsError, OdpResourceNotFoundError
+from odp.client.http_client import OdpHttpClient
 from odp.client.tabular_storage_client import OdpTabularStorageClient
+from odp.dto import DatasetDto
 from pandas import DataFrame
 
 
 @pytest.fixture()
-def tabular_storage_client(http_client) -> OdpTabularStorageClient:
+def tabular_storage_client(http_client: OdpHttpClient) -> OdpTabularStorageClient:
     return OdpTabularStorageClient(http_client=http_client, tabular_storage_endpoint="/data")
 
 
-def test_create_schema_success(tabular_storage_client, tabular_resource_dto, table_spec):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            body=table_spec.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
+def test_create_schema_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_spec: TableSpec,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        body=table_spec.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
 
-        result = tabular_storage_client.create_schema(tabular_resource_dto, table_spec)
+    result = tabular_storage_client.create_schema(tabular_resource_dto, table_spec)
 
-        assert result.table_schema == table_spec.table_schema
-        assert result.partitioning == table_spec.partitioning
-
-
-def test_create_schema_fail_409(tabular_storage_client, tabular_resource_dto, table_spec):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=409,
-        )
-
-        with pytest.raises(OdpResourceExistsError):
-            tabular_storage_client.create_schema(tabular_resource_dto, table_spec)
+    assert result.table_schema == table_spec.table_schema
+    assert result.partitioning == table_spec.partitioning
 
 
-def test_get_schema_success(tabular_storage_client, tabular_resource_dto, table_spec):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            body=table_spec.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
+def test_create_schema_fail_409(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_spec: TableSpec,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        status=409,
+    )
 
-        result = tabular_storage_client.get_schema(tabular_resource_dto)
-
-        assert result.table_schema == table_spec.table_schema
-        assert result.partitioning == table_spec.partitioning
-
-
-def test_get_schema_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=404,
-        )
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.get_schema(tabular_resource_dto)
+    with pytest.raises(OdpResourceExistsError):
+        tabular_storage_client.create_schema(tabular_resource_dto, table_spec)
 
 
-def test_delete_schema_success(tabular_storage_client, tabular_resource_dto):
+def test_get_schema_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_spec: TableSpec,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        body=table_spec.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
+
+    result = tabular_storage_client.get_schema(tabular_resource_dto)
+
+    assert result.table_schema == table_spec.table_schema
+    assert result.partitioning == table_spec.partitioning
+
+
+def test_get_schema_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        status=404,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
+        tabular_storage_client.get_schema(tabular_resource_dto)
+
+
+def test_delete_schema_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema") + "?delete_data=False"
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.DELETE,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.DELETE,
+        url,
+        status=200,
+    )
 
+    tabular_storage_client.delete_schema(tabular_resource_dto)
+
+    assert request_mock.assert_call_count(url, 1)
+
+
+def test_delete_schema_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.DELETE,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        status=404,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
         tabular_storage_client.delete_schema(tabular_resource_dto)
 
-        assert rsps.assert_call_count(url, 1)
+
+def test_create_stage_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
+        body=table_stage.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
+
+    result = tabular_storage_client.create_stage_request(tabular_resource_dto)
+
+    assert result.stage_id == table_stage.stage_id
 
 
-def test_delete_schema_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.DELETE,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=404,
-        )
+def test_create_stage_fail_409(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
+        status=409,
+    )
 
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.delete_schema(tabular_resource_dto)
-
-
-def test_create_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
-            body=table_stage.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
-
-        result = tabular_storage_client.create_stage_request(tabular_resource_dto)
-
-        assert result.stage_id == table_stage.stage_id
+    with pytest.raises(OdpResourceExistsError):
+        tabular_storage_client.create_stage_request(tabular_resource_dto)
 
 
-def test_create_stage_fail_409(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
-            status=409,
-        )
-
-        with pytest.raises(OdpResourceExistsError):
-            tabular_storage_client.create_stage_request(tabular_resource_dto)
-
-
-def test_commit_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
+def test_commit_stage_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            url,
-            status=200,
-        )
-        tabular_storage_client.commit_stage_request(tabular_resource_dto, table_stage)
+    request_mock.add(
+        responses.POST,
+        url,
+        status=200,
+    )
+    tabular_storage_client.commit_stage_request(tabular_resource_dto, table_stage)
 
-        assert rsps.assert_call_count(url, 1)
-
-
-def test_get_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
-            body=table_stage.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
-            body=table_stage.model_dump_json(),
-            status=200,
-            content_type="application/json",
-        )
-
-        result_uuid = tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage.stage_id)
-        result_table_stage = tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage)
-
-        assert result_uuid.stage_id == table_stage.stage_id
-        assert result_table_stage.stage_id == table_stage.stage_id
+    assert request_mock.assert_call_count(url, 1)
 
 
-def test_get_stage_fail_400(tabular_storage_client, tabular_resource_dto, table_stage):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
-            status=400,
-        )
+def test_get_stage_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
+        body=table_stage.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
+        body=table_stage.model_dump_json(),
+        status=200,
+        content_type="application/json",
+    )
 
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage.stage_id)
+    result_uuid = tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage.stage_id)
+    result_table_stage = tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage)
 
-
-def test_list_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
-            body=f"[{table_stage.model_dump_json()}, {table_stage.model_dump_json()}]",
-            status=200,
-            content_type="application/json",
-        )
-
-        result = tabular_storage_client.list_stage_request(tabular_resource_dto)
-
-        assert len(result) == 2
-
-
-def test_list_stage_fail_400(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
-            status=400,
-        )
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.list_stage_request(tabular_resource_dto)
+    assert result_uuid.stage_id == table_stage.stage_id
+    assert result_table_stage.stage_id == table_stage.stage_id
 
 
-def test_delete_stage_success(tabular_storage_client, tabular_resource_dto, table_stage):
+def test_get_stage_fail_400(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
+        status=400,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
+        tabular_storage_client.get_stage_request(tabular_resource_dto, table_stage.stage_id)
+
+
+def test_list_stage_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
+        body=f"[{table_stage.model_dump_json()}, {table_stage.model_dump_json()}]",
+        status=200,
+        content_type="application/json",
+    )
+
+    result = tabular_storage_client.list_stage_request(tabular_resource_dto)
+
+    assert len(result) == 2
+
+
+def test_list_stage_fail_400(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage"),
+        status=400,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
+        tabular_storage_client.list_stage_request(tabular_resource_dto)
+
+
+def test_delete_stage_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
     url = (
         tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id))
         + "?force_delete=False"
     )
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.DELETE,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.DELETE,
+        url,
+        status=200,
+    )
 
+    tabular_storage_client.delete_stage_request(tabular_resource_dto, table_stage)
+
+    assert request_mock.assert_call_count(url, 1)
+
+
+def test_delete_stage_fail_400(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.DELETE,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
+        status=400,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
         tabular_storage_client.delete_stage_request(tabular_resource_dto, table_stage)
 
-        assert rsps.assert_call_count(url, 1)
+
+def test_select_as_stream_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}',
+        status=200,
+        content_type="application/x-ndjson",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        status=404,
+    )
+
+    response = tabular_storage_client.select_as_stream(tabular_resource_dto, filter_query=None)
+    response_as_list = list(response)
+
+    assert len(response_as_list) == 2
+    assert response_as_list[0]["test_key1"] == "test_value"
+    assert response_as_list[1]["test_key2"] == "test_value2"
 
 
-def test_delete_stage_fail_400(tabular_storage_client, tabular_resource_dto, table_stage):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.DELETE,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "stage", str(table_stage.stage_id)),
-            status=400,
-        )
+def test_select_as_list_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
+        status=200,
+        content_type="application/x-ndjson",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        json={"table_schema": {"test_key1": {"type": "string"}, "test_key2": {"type": "string"}}},
+        status=200,
+    )
 
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.delete_stage_request(tabular_resource_dto, table_stage)
+    response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
+
+    assert len(response) == 2
+    assert response[0]["test_key1"] == "test_value"
+    assert response[1]["test_key2"] == "test_value2"
 
 
-def test_select_as_stream_success(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}',
-            status=200,
-            content_type="application/x-ndjson",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=404,
-        )
+def test_select_as_list_wkt_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    table_spec: TableSpec,
+    table_stage: TableStage,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        body='{"test_key1": "POINT(0 0)"}\n{"test_key1": "POINT(0 1)"}\n{"@@end": true}',
+        status=200,
+        content_type="application/x-ndjson",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        json={"table_schema": {"test_key1": {"type": "geometry"}}},
+        status=200,
+    )
 
+    response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
+
+    assert len(response) == 2
+    assert response[0]["test_key1"] == {"coordinates": [0.0, 0.0], "type": "Point"}
+    assert response[1]["test_key1"] == {"coordinates": [0.0, 1.0], "type": "Point"}
+
+
+def test_select_as_list_wkb_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        body='{"test_key1": "010100000000000000000000000000000000000000"}\n'
+        '{"test_key2": "01010000000000000000000000000000000000f03f"}\n{"@@end": true}',
+        status=200,
+        content_type="application/x-ndjson",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        json={"table_schema": {"test_key1": {"type": "geometry"}, "test_key2": {"type": "geometry"}}},
+        status=200,
+    )
+
+    response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
+
+    assert len(response) == 2
+    assert response[0]["test_key1"] == {"coordinates": [0.0, 0.0], "type": "Point"}
+    assert response[1]["test_key2"] == {"coordinates": [0.0, 1.0], "type": "Point"}
+
+
+def test_select_as_stream_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        status=404,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
         response = tabular_storage_client.select_as_stream(tabular_resource_dto, filter_query=None)
-        response_as_list = list(response)
-
-        assert len(response_as_list) == 2
-        assert response_as_list[0]["test_key1"] == "test_value"
-        assert response_as_list[1]["test_key2"] == "test_value2"
+        list(response)
 
 
-def test_select_as_list_success(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "test_value"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
-            status=200,
-            content_type="application/x-ndjson",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            json={"table_schema": {"test_key1": {"type": "string"}, "test_key2": {"type": "string"}}},
-            status=200,
-        )
+def test_select_as_list_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        status=404,
+    )
 
-        response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
-
-        assert len(response) == 2
-        assert response[0]["test_key1"] == "test_value"
-        assert response[1]["test_key2"] == "test_value2"
+    with pytest.raises(OdpResourceNotFoundError):
+        tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
 
 
-def test_select_as_list_wkt_success(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "POINT(0 0)"}\n{"test_key1": "POINT(0 1)"}\n{"@@end": true}',
-            status=200,
-            content_type="application/x-ndjson",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            json={"table_schema": {"test_key1": {"type": "geometry"}}},
-            status=200,
-        )
+def test_select_as_dataframe(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
+        body='{"test_key1": "Cameroonian Exclusive Economic Zone"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
+        status=200,
+        content_type="application/x-ndjson",
+    )
+    request_mock.add(
+        responses.GET,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
+        status=404,
+    )
 
-        response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
+    response = tabular_storage_client.select_as_dataframe(tabular_resource_dto, filter_query=None)
 
-        assert len(response) == 2
-        assert response[0]["test_key1"] == {"coordinates": [0.0, 0.0], "type": "Point"}
-        assert response[1]["test_key1"] == {"coordinates": [0.0, 1.0], "type": "Point"}
-
-
-def test_select_as_list_wkb_success(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "010100000000000000000000000000000000000000"}\n'
-            '{"test_key2": "01010000000000000000000000000000000000f03f"}\n{"@@end": true}',
-            status=200,
-            content_type="application/x-ndjson",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            json={"table_schema": {"test_key1": {"type": "geometry"}, "test_key2": {"type": "geometry"}}},
-            status=200,
-        )
-
-        response = tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
-
-        assert len(response) == 2
-        assert response[0]["test_key1"] == {"coordinates": [0.0, 0.0], "type": "Point"}
-        assert response[1]["test_key2"] == {"coordinates": [0.0, 1.0], "type": "Point"}
+    assert len(response) == 2
+    assert response["test_key1"][0] == "Cameroonian Exclusive Economic Zone"
+    assert response["test_key2"][1] == "test_value2"
 
 
-def test_select_as_stream_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            status=404,
-        )
-
-        with pytest.raises(OdpResourceNotFoundError):
-            response = tabular_storage_client.select_as_stream(tabular_resource_dto, filter_query=None)
-            list(response)
-
-
-def test_select_as_list_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            status=404,
-        )
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.select_as_list(tabular_resource_dto, filter_query=None)
-
-
-def test_select_as_dataframe(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "list"),
-            body='{"test_key1": "Cameroonian Exclusive Economic Zone"}\n{"test_key2": "test_value2"}\n{"@@end": true}',
-            status=200,
-            content_type="application/x-ndjson",
-        )
-        rsps.add(
-            responses.GET,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "schema"),
-            status=404,
-        )
-
-        response = tabular_storage_client.select_as_dataframe(tabular_resource_dto, filter_query=None)
-
-        assert len(response) == 2
-        assert response["test_key1"][0] == "Cameroonian Exclusive Economic Zone"
-        assert response["test_key2"][1] == "test_value2"
-
-
-def test_write_small_success(tabular_storage_client, tabular_resource_dto):
+def test_write_small_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.POST,
+        url,
+        status=200,
+    )
 
-        data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
+    data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
 
+    tabular_storage_client.write(tabular_resource_dto, data, table_stage=None)
+
+    assert request_mock.assert_call_count(url, 1)
+
+
+def test_write_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto),
+        status=404,
+    )
+
+    data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
+
+    with pytest.raises(OdpResourceNotFoundError):
         tabular_storage_client.write(tabular_resource_dto, data, table_stage=None)
 
-        assert rsps.assert_call_count(url, 1)
 
-
-def test_write_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto),
-            status=404,
-        )
-
-        data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.write(tabular_resource_dto, data, table_stage=None)
-
-
-def test_write_as_dataframe(tabular_storage_client, tabular_resource_dto):
+def test_write_as_dataframe(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.POST,
+        url,
+        status=200,
+    )
 
-        data = DataFrame([{"test_key1": "test_value"}, {"test_key2": "test_value2"}])
+    data = DataFrame([{"test_key1": "test_value"}, {"test_key2": "test_value2"}])
 
-        tabular_storage_client.write_dataframe(tabular_resource_dto, data, table_stage=None)
+    tabular_storage_client.write_dataframe(tabular_resource_dto, data, table_stage=None)
 
-        assert rsps.assert_call_count(url, 1)
+    assert request_mock.assert_call_count(url, 1)
 
 
-def test_delete_success(tabular_storage_client, tabular_resource_dto):
+def test_delete_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto, "delete")
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.POST,
+        url,
+        status=200,
+    )
 
+    tabular_storage_client.delete(tabular_resource_dto, filter_query=None)
+
+    assert request_mock.assert_call_count(url, 1)
+
+
+def test_delete_fail_400(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.POST,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto, "delete"),
+        status=404,
+    )
+
+    with pytest.raises(OdpResourceNotFoundError):
         tabular_storage_client.delete(tabular_resource_dto, filter_query=None)
 
-        assert rsps.assert_call_count(url, 1)
 
-
-def test_delete_fail_400(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.POST,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto, "delete"),
-            status=404,
-        )
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.delete(tabular_resource_dto, filter_query=None)
-
-
-def test_update_success(tabular_storage_client, tabular_resource_dto):
+def test_update_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.PATCH,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.PATCH,
+        url,
+        status=200,
+    )
 
-        data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
+    data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
 
+    tabular_storage_client.update(tabular_resource_dto, filter_query=dict(), data=data)
+
+    assert request_mock.assert_call_count(url, 1)
+
+
+def test_update_fail_404(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
+    request_mock.add(
+        responses.PATCH,
+        tabular_storage_client.tabular_endpoint(tabular_resource_dto),
+        status=404,
+    )
+
+    data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
+
+    with pytest.raises(OdpResourceNotFoundError):
         tabular_storage_client.update(tabular_resource_dto, filter_query=dict(), data=data)
 
-        assert rsps.assert_call_count(url, 1)
 
-
-def test_update_fail_404(tabular_storage_client, tabular_resource_dto):
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.PATCH,
-            tabular_storage_client.tabular_endpoint(tabular_resource_dto),
-            status=404,
-        )
-
-        data = [{"test_key1": "test_value"}, {"test_key2": "test_value2"}]
-
-        with pytest.raises(OdpResourceNotFoundError):
-            tabular_storage_client.update(tabular_resource_dto, filter_query=dict(), data=data)
-
-
-def test_update_dataframe_success(tabular_storage_client, tabular_resource_dto):
+def test_update_dataframe_success(
+    tabular_storage_client: OdpTabularStorageClient,
+    tabular_resource_dto: DatasetDto,
+    request_mock: responses.RequestsMock,
+):
     url = tabular_storage_client.tabular_endpoint(tabular_resource_dto)
 
-    with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.PATCH,
-            url,
-            status=200,
-        )
+    request_mock.add(
+        responses.PATCH,
+        url,
+        status=200,
+    )
 
-        data = DataFrame([{"test_key1": "test_value"}, {"test_key2": "test_value2"}])
+    data = DataFrame([{"test_key1": "test_value"}, {"test_key2": "test_value2"}])
 
-        tabular_storage_client.update_dataframe(tabular_resource_dto, filter_query=None, data=data)
+    tabular_storage_client.update_dataframe(tabular_resource_dto, filter_query=None, data=data)
 
-        assert rsps.assert_call_count(url, 1)
+    assert request_mock.assert_call_count(url, 1)


### PR DESCRIPTION
Closes: ODP-1300

- Added more unit tests to SDK
- Updated existing SDK unit tests to use new request-mock fixture
- Added type hints to most of existing unit tests
- Added time-control fixtures sdk test suite

The issue ODP-1300 indicate that access token is not successfully renewed after expiry, however this was not reproducible. Added tests to make sure token is renewed.