### PR TITLE
Remove `OdpTabularStorageClient` default limits for select

### DIFF
--- a/src/sdk/odp/client/tabular_storage_client.py
+++ b/src/sdk/odp/client/tabular_storage_client.py
@@ -289,7 +289,6 @@ class OdpTabularStorageClient(BaseModel):
         resource_dto: DatasetDto,
         filter_query: Optional[dict] = None,
         limit: Optional[int] = None,
-        cursor: Optional[str] = None,
     ) -> list[dict]:
         """Select data from dataset
 
@@ -297,7 +296,6 @@ class OdpTabularStorageClient(BaseModel):
             resource_dto: Dataset manifest
             filter_query: Filter query in OQS format
             limit: limit for the number of rows returned
-            cursor: pointer to next list page
 
         Returns:
             Data that is queried as a list


### PR DESCRIPTION
Removed `OdpTabularStorageClient` default limits and cursor-argument for select-functions. Let API decide how pagination is handled