### PR TITLE
ODP-1369: Only replace if Bearer

### DIFF
--- a/src/sdk/odp/client/auth.py
+++ b/src/sdk/odp/client/auth.py
@@ -76,8 +76,8 @@ class OdpWorkspaceTokenProvider(TokenProvider):
         res = requests.post(self.token_uri)
         res.raise_for_status()
 
-        token = res.json()["token"]
-        claims = jwt.decode(token[7:], options={"verify_signature": False})  # skip "Bearer "-prefix
+        token: str = res.json()["token"]
+        claims = jwt.decode(token.replace("Bearer ", ""), options={"verify_signature": False})
         self._user_id = claims[self.user_id_claim]
 
         return "Bearer " + res.json()["token"]


### PR DESCRIPTION
Closes ODP-1369

This PR addresses an issue with the `OdpWorkspaceTokenProvider` authentication mechanism within the SDK, where it previously assumed that the token string always contained the "Bearer " keyword and subsequently removed the first 7 characters of the token. This approach led to errors in scenarios where the "Bearer " keyword was absent from the token string. To resolve this, the PR removes the "Bearer " keyword from the token string, if present, using the replace method. This ensures that the token is correctly processed regardless of whether the "Bearer " keyword is included.