### PR TITLE
ODP-1508: Add file encoding in raw controller

### DIFF
--- a/src/sdk/odp/client/dto/file_dto.py
+++ b/src/sdk/odp/client/dto/file_dto.py
@@ -1,20 +1,26 @@
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 
 class FileMetadataDto(BaseModel):
     """File Metadata Model."""
 
-    name: Optional[Any] = None
-    mime_type: Optional[Any] = None
+    name: str
+    mime_type: Optional[str] = None
     dataset: Optional[UUID] = None
-    metadata: Optional[Dict[Any, Any]] = None
+    metadata: Dict[str, Union[bool, int, str]] = Field(default_factory=dict)
     geo_location: Optional[Any] = None
     size_bytes: Optional[int] = None
     checksum: Optional[str] = None
     created_time: Optional[datetime] = None
     modified_time: Optional[datetime] = None
     deleted_time: Optional[datetime] = None
+
+    @field_validator("name")
+    def lstrip_name(cls, v):
+        if v.startswith("/"):
+            raise ValueError("name cannot start with '/'. Absolute paths are not allowed.")
+        return v

--- a/src/sdk/tests/test_sdk/test_utils/test_dto.py
+++ b/src/sdk/tests/test_sdk/test_utils/test_dto.py
@@ -1,0 +1,15 @@
+import pytest
+from odp.client.dto.file_dto import FileMetadataDto
+
+
+@pytest.mark.parametrize(
+    "file_name, correct",
+    [("test.txt", True), ("foo/bar/test2.txt", True), ("/test.txt", False), ("/foo/bar/test2.txt", False)],
+)
+def test_file_dto_names(file_name, correct):
+    if correct:
+        file_metadata = FileMetadataDto(name=file_name)
+        assert file_metadata.name == file_name
+    else:
+        with pytest.raises(ValueError):
+            FileMetadataDto(name=file_name)

--- a/tests/test_examples/conftest.py
+++ b/tests/test_examples/conftest.py
@@ -66,8 +66,8 @@ def odp_client_test_uuid(odp_client: OdpClient) -> Tuple[OdpClient, uuid.UUID]:
         if "raw" in storage_class:
             for file in odp_client.raw.list(manifest):
                 delete_element(odp_client.raw.delete_file, manifest, file)
-                if os.path.exists(file.name):
-                    os.remove(file.name)
+                if os.path.exists(os.path.basename(file.name)):
+                    os.remove(os.path.basename(file.name))
         if "tabular" in storage_class:
             delete_element(odp_client.tabular.delete_schema, manifest, True)
         delete_element(odp_client.catalog.delete, manifest.metadata.uuid)

--- a/tests/test_examples/test_raw_client_example.py
+++ b/tests/test_examples/test_raw_client_example.py
@@ -4,12 +4,14 @@ import string
 from typing import Tuple
 from uuid import UUID
 
+import pytest
 from odp.client import OdpClient
 from odp.client.dto.file_dto import FileMetadataDto
 from odp.dto import DatasetDto, DatasetSpec
 
 
-def test_raw_client(odp_client_test_uuid: Tuple[OdpClient, UUID]):
+@pytest.mark.parametrize("file_name", ["test.txt", "foo/bar/test2.txt"])
+def test_raw_client(odp_client_test_uuid: Tuple[OdpClient, UUID], file_name):
     my_dataset = DatasetDto(
         **{
             "kind": "catalog.hubocean.io/dataset",
@@ -31,7 +33,7 @@ def test_raw_client(odp_client_test_uuid: Tuple[OdpClient, UUID]):
 
     file_dto = odp_client_test_uuid[0].raw.create_file(
         resource_dto=my_dataset,
-        file_metadata_dto=FileMetadataDto(**{"name": "test.txt", "mime_type": "text/plain"}),
+        file_metadata_dto=FileMetadataDto(**{"name": file_name, "mime_type": "text/plain"}),
         contents=b"Hello, World!",
     )
 
@@ -39,5 +41,6 @@ def test_raw_client(odp_client_test_uuid: Tuple[OdpClient, UUID]):
         assert isinstance(file, FileMetadataDto)
     assert odp_client_test_uuid[0].raw.list(my_dataset) != []
 
-    odp_client_test_uuid[0].raw.download_file(my_dataset, file_dto, "test.txt")
-    assert os.path.exists("test.txt")
+    save_path = os.path.basename(file_name)
+    odp_client_test_uuid[0].raw.download_file(my_dataset, file_dto, save_path)
+    assert os.path.exists(save_path)


### PR DESCRIPTION
Adds file name encoding to support paths as filenames

* Absolute paths are forbidden
* Testing of new case

Until the https://github.com/C4IROcean/app-odcat/pull/1171 is not released, the paths are going to be taken as a string:

* foo/bar/text.txt - > foo%2F%bar%2Ftext.txt